### PR TITLE
Ffmpeg

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,6 +26,8 @@
 - [ ] `--skip` ani-skip works
 - [ ] `--skip-title` ani-skip title argument works
 - [ ] `--no-detach` no detach works
+- [ ] `--exit-after-play` auto exit after playing works
+- [ ] `--nextep-countdown` countdown to next ep works
 - [ ] `--dub` and regular (sub) mode both work
 - [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
 ---

--- a/ani-cli
+++ b/ani-cli
@@ -298,7 +298,7 @@ download() {
             [ -e "$download_dir/$2.vtt" ] && ffmpeg -loglevel error -i "$download_dir/$2.mp4" -i "$download_dir/$2.vtt" -c copy -c:s mov_text "$download_dir/$2.bak.mp4" && mv "$download_dir/$2.bak.mp4" "$download_dir/$2.mp4" && rm "$download_dir/$2.vtt"
             ;;
         *)
-            aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue --async-dns=false --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+            ffmpeg -referer "$allanime_refr" -loglevel error -stats -i "$1" -codec:v libx264 -vf "scale='min(640,iw)':'min(360,ih)'" -preset medium -codec:a aac -crf 34 -b:a 64k "$download_dir/$2.mp4"
             ;;
     esac
 }

--- a/ani-cli
+++ b/ani-cli
@@ -3,7 +3,7 @@
 [ -e "$HOME/.config/mpv" ] && export MPV_HOME="$HOME/.config/mpv"
 [ ! -e "$APPDATA" ] && export HOME=$HOME/.cache/ani-cli
 # [ -e "$CMDER_ROOT" ] && export HOME=$CMDER_ROOT/opt/home/.cache/ani-cli
-[ ! -e "$APPDATA" ] && [ ! -e "$HOME/yt-dlp.conf" ] && mkdir $HOME && TMP_DIR=$(mktemp --directory) && echo "--paths temp:$TMP_DIR -S res:360">> "$HOME/yt-dlp.conf"
+[ ! -e "$APPDATA" ] && [ ! -e "$HOME/yt-dlp.conf" ] && mkdir $HOME 2>/dev/null & TMP_DIR=$(mktemp --directory) && echo "--paths temp:$TMP_DIR -S res:360">> "$HOME/yt-dlp.conf"
 
 version_number="4.10.0"
 

--- a/ani-cli
+++ b/ani-cli
@@ -3,7 +3,7 @@
 [ -e "$HOME/.config/mpv" ] && export MPV_HOME="$HOME/.config/mpv"
 [ ! -e "$APPDATA" ] && export HOME=$HOME/.cache/ani-cli
 # [ -e "$CMDER_ROOT" ] && export HOME=$CMDER_ROOT/opt/home/.cache/ani-cli
-[ ! -e "$APPDATA" ] && [ ! -e "$HOME/yt-dlp.conf" ] && mkdir $HOME 2>/dev/null & TMP_DIR=$(mktemp --directory) && echo "--paths temp:$TMP_DIR -S res:360">> "$HOME/yt-dlp.conf"
+[ ! -e "$APPDATA" ] && mkdir $HOME 2>/dev/null & TMP_DIR=$(mktemp --directory) && echo "--paths temp:$TMP_DIR -S res:360"> "$HOME/yt-dlp.conf"
 
 version_number="4.10.0"
 

--- a/ani-cli
+++ b/ani-cli
@@ -144,6 +144,8 @@ get_links() {
     response="$(curl -e "$allanime_refr" -s "https://${allanime_base}$*" -A "$agent")"
     episode_link="$(printf '%s' "$response" | sed 's|},{|\
 |g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
+    printf '%s' "$response" | grep -q "master.m3u8" && m3u8_refr=$(printf '%s' "$response" | sed -nE 's|.*Referer":"([^"]*)".*|\1|p') &&
+        printf '%s\n' "m3u8_refr >$m3u8_refr" > "$cache_dir/m3u8_refr"
 
     case "$episode_link" in
         *repackager.wixmp.com*)
@@ -187,17 +189,20 @@ generate_link() {
 
 select_quality() {
     # removing urls which have soft subs to avoid playing on android and iSH
-    printf '%s' "$player_function" | grep -qE '(android|iSH|vlc)' && links=$(printf '%s' "$links" | sed '/cc>/d;/subtitle >/d;/Yt >/d')
+    printf '%s' "$player_function" | grep -qE '(android|iSH|vlc)' && links=$(printf '%s' "$links" | sed '/cc>/d;/subtitle >/d;/m3u8_refr >/d')
     case "$1" in
         best) result=$(printf "%s" "$links" | head -n1) ;;
         worst) result=$(printf "%s" "$links" | grep -E '^[0-9]{3,4}' | tail -n1) ;;
         *) result=$(printf "%s" "$links" | grep -m 1 "$1") ;;
     esac
     [ -z "$result" ] && printf "Specified quality not found, defaulting to best\n" 1>&2 && result=$(printf "%s" "$links" | head -n1)
+
+    # add refr,sub flags for m3u8 and refr flag for yt
     printf '%s' "$result" | grep -q "cc>" && subtitle="$(printf '%s' "$links" | sed -nE 's|subtitle >(.*)|\1|p')" &&
         [ -n "$subtitle" ] && subs_flag="--sub-file=$subtitle"
-    printf '%s' "$result" | grep -q "cc>" && refr_flag="--referrer=$m3u8_refr"
-    printf "%s" "$result" | grep -q "tools.fast4speed.rsvp" && refr_flag="--referrer=https://youtu-chan.com"
+    printf '%s' "$result" | grep -q "cc>" && m3u8_refr="$(printf '%s' "$links" | sed -nE 's|m3u8_refr >(.*)|\1|p')" && refr_flag="--referrer=$m3u8_refr"
+    printf "%s" "$result" | grep -q "tools.fast4speed.rsvp" && refr_flag="--referrer=$allanime_refr"
+
     ! (printf '%s' "$result" | grep -qE "(cc>|tools.fast4speed.rsvp)") && unset refr_flag
     ! (printf '%s' "$result" | grep -q "cc>") && unset subs_flag
     episode=$(printf "%s" "$result" | cut -d'>' -f2)
@@ -294,7 +299,7 @@ download() {
             [ -e "$download_dir/$2.vtt" ] && ffmpeg -loglevel error -i "$download_dir/$2.mp4" -i "$download_dir/$2.vtt" -c copy -c:s mov_text "$download_dir/$2.bak.mp4" && mv "$download_dir/$2.bak.mp4" "$download_dir/$2.mp4" && rm "$download_dir/$2.vtt"
             ;;
         *)
-            aria2c --enable-rpc=false --check-certificate=false --continue --async-dns=false --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
+            aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue --async-dns=false --summary-interval=0 -x 16 -s 16 "$1" --dir="$download_dir" -o "$2.mp4" --download-result=hide
             ;;
     esac
 }
@@ -322,7 +327,7 @@ play_episode() {
         android_vlc) nohup am start --user 0 -a android.intent.action.VIEW -d "$episode" -n org.videolan.vlc/org.videolan.vlc.gui.video.VideoPlayerActivity -e "title" "${allanime_title}Episode ${ep_no}" >/dev/null 2>&1 & ;;
         *iina*) nohup "$player_function" --no-stdin --keep-running --mpv-force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag "$episode" >/dev/null 2>&1 & ;;
         flatpak_mpv) flatpak run io.mpv.Mpv --force-media-title="${allanime_title}Episode ${ep_no}" "$episode" $subs_flag $refr_flag >/dev/null 2>&1 & ;;
-        vlc*) nohup "$player_function" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
+        vlc*) nohup "$player_function" --http-referrer="${allanime_refr}" --play-and-exit --meta-title="${allanime_title}Episode ${ep_no}" "$episode" >/dev/null 2>&1 & ;;
         *yncpla*) nohup "$player_function" "$episode" -- --force-media-title="${allanime_title}Episode ${ep_no}" $subs_flag $refr_flag >/dev/null 2>&1 & ;;
         download) "$player_function" "$episode" "${allanime_title}Episode ${ep_no}" "$subtitle" ;;
         catt) nohup catt cast "$episode" -s "$subtitle" >/dev/null 2>&1 & ;;
@@ -368,7 +373,6 @@ play() {
 
 # setup
 agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0"
-m3u8_refr="https://megacloud.club/"
 allanime_refr="https://allmanga.to"
 allanime_base="allanime.day"
 allanime_api="https://api.${allanime_base}"

--- a/ani-cli
+++ b/ani-cli
@@ -3,7 +3,7 @@
 [ -e "$HOME/.config/mpv" ] && export MPV_HOME="$HOME/.config/mpv"
 [ ! -e "$APPDATA" ] && export HOME=$HOME/.cache/ani-cli
 # [ -e "$CMDER_ROOT" ] && export HOME=$CMDER_ROOT/opt/home/.cache/ani-cli
-[ ! -e "$APPDATA" ] && YTDLPPATH=--paths temp:~/.cache
+[ ! -e "$APPDATA" ] && [ ! -e "$HOME/yt-dlp.conf" ] && mkdir $HOME && TMP_DIR=$(mktemp --directory) && echo "--paths temp:$TMP_DIR">> "$HOME/yt-dlp.conf"
 
 version_number="4.10.0"
 
@@ -286,7 +286,7 @@ download() {
     case $1 in
         *m3u8*)
             if command -v "yt-dlp" >/dev/null; then
-                yt-dlp --referer "$m3u8_refr" "$1" --no-skip-unavailable-fragments --fragment-retries infinite -N 16 -o "$download_dir/$2.mp4" $(YTDLPPATH)
+                yt-dlp --referer "$m3u8_refr" "$1" --no-skip-unavailable-fragments --fragment-retries infinite -N 16 -o "$download_dir/$2.mp4"
             else
                 ffmpeg -referer "$m3u8_refr" -loglevel error -stats -i "$1" -c copy "$download_dir/$2.mp4"
             fi

--- a/ani-cli
+++ b/ani-cli
@@ -3,7 +3,7 @@
 [ -e "$HOME/.config/mpv" ] && export MPV_HOME="$HOME/.config/mpv"
 [ ! -e "$APPDATA" ] && export HOME=$HOME/.cache/ani-cli
 # [ -e "$CMDER_ROOT" ] && export HOME=$CMDER_ROOT/opt/home/.cache/ani-cli
-[ ! -e "$APPDATA" ] && [ ! -e "$HOME/yt-dlp.conf" ] && mkdir $HOME && TMP_DIR=$(mktemp --directory) && echo "--paths temp:$TMP_DIR">> "$HOME/yt-dlp.conf"
+[ ! -e "$APPDATA" ] && [ ! -e "$HOME/yt-dlp.conf" ] && mkdir $HOME && TMP_DIR=$(mktemp --directory) && echo "--paths temp:$TMP_DIR -S res:360">> "$HOME/yt-dlp.conf"
 
 version_number="4.10.0"
 

--- a/ani-cli
+++ b/ani-cli
@@ -144,8 +144,6 @@ get_links() {
     response="$(curl -e "$allanime_refr" -s "https://${allanime_base}$*" -A "$agent")"
     episode_link="$(printf '%s' "$response" | sed 's|},{|\
 |g' | sed -nE 's|.*link":"([^"]*)".*"resolutionStr":"([^"]*)".*|\2 >\1|p;s|.*hls","url":"([^"]*)".*"hardsub_lang":"en-US".*|\1|p')"
-    printf '%s' "$response" | grep -q "master.m3u8" && m3u8_refr=$(printf '%s' "$response" | sed -nE 's|.*Referer":"([^"]*)".*|\1|p') &&
-        printf '%s\n' "m3u8_refr >$m3u8_refr" > "$cache_dir/m3u8_refr"
 
     case "$episode_link" in
         *repackager.wixmp.com*)
@@ -156,6 +154,7 @@ get_links() {
             done | sort -nr
             ;;
         *master.m3u8*)
+            m3u8_refr=$(printf '%s' "$response" | sed -nE 's|.*Referer":"([^"]*)".*|\1|p') && printf '%s\n' "m3u8_refr >$m3u8_refr" >"$cache_dir/m3u8_refr"
             extract_link=$(printf "%s" "$episode_link" | head -1 | cut -d'>' -f2)
             relative_link=$(printf "%s" "$extract_link" | sed 's|[^/]*$||')
             curl -e "$m3u8_refr" -s "$extract_link" -A "$agent" | sed 's|^#EXT-X-STREAM.*x||g; s|,.*|p|g; /^#/d; $!N; s|\
@@ -188,7 +187,7 @@ generate_link() {
 }
 
 select_quality() {
-    # removing urls which have soft subs to avoid playing on android and iSH
+    # removing urls which have soft subs to avoid playing on android and iSH and vlc (m3u8 streams don't get correct referrer)
     printf '%s' "$player_function" | grep -qE '(android|iSH|vlc)' && links=$(printf '%s' "$links" | sed '/cc>/d;/subtitle >/d;/m3u8_refr >/d')
     case "$1" in
         best) result=$(printf "%s" "$links" | head -n1) ;;
@@ -223,7 +222,7 @@ get_episode_url() {
     done
     wait
     # select the link with matching quality
-    links=$(cat "$cache_dir"/* | sed 's|^Mp4-||g;/http/!d;/Alt/d;' | sort -g -r -s)
+    links=$(cat "$cache_dir"/* | sort -g -r -s)
     rm -r "$cache_dir"
     select_quality "$quality"
     if printf "%s" "$ep_list" | grep -q "^$ep_no$"; then

--- a/ani-cli.1
+++ b/ani-cli.1
@@ -63,6 +63,7 @@ Use ani-skip to skip the intro of the episode (mpv only)
 .TP
 \fB\--no-detach\fR
 Don't detach the player (useful for in-terminal playback, mpv only)
+.TP
 \fB\--exit-after-play\fR
 Exit the player, and return the player exit code (useful for non interactive scenarios, mpv only)
 .TP


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- The examples of the help text
