### PR TITLE
Update ani-cli

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -294,8 +294,12 @@ download() {
     [ -n "$subtitle" ] && ffmpegsubtitle="-i $subtitle -c:s mov_text"
     case $1 in
         *m3u8*)
+            if command -v "yt-dlp" >/dev/null; then
+            [ ! -e "$download_dir/$2.mp4" ] && yt-dlp --referer "$m3u8_refr" "$1" $mpegts --no-skip-unavailable-fragments --fragment-retries infinite -N 10 -o - | ffmpeg -loglevel error -stats -i - $ffmpegsubtitle $ffmpegconvter "$TMP_DIR/$2.mp4"
+            else
             [ -e "$APPDATA" ] && extension_picky="-extension_picky 0"
             [ ! -e "$download_dir/$2.mp4" ] && ffmpeg $extension_picky -referer "$m3u8_refr" -loglevel error -stats -i "$1" $ffmpegsubtitle $ffmpegconvter "$TMP_DIR/$2.mp4"
+            fi
             # embed subs into downloads
             # [ -n "$subtitle" ] && ffmpeg -loglevel error -i "$TMP_DIR/$2.mp4" -i "$subtitle" -c copy "$TMP_DIR/$2.bak.mp4" && mv "$TMP_DIR/$2.bak.mp4" "$TMP_DIR/$2.mp4"
             ;;


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
