### PR TITLE
Update ani-cli

### DIFF
--- a/ani-cli
+++ b/ani-cli
@@ -107,7 +107,7 @@ version_info() {
 }
 
 update_script() {
-    update="$(curl -s -A "$agent" "https://raw.githubusercontent.com/candrapersada/ani-cli/sub/ani-cli")" || die "Connection error"
+    update="$(curl -s -A "$agent" "https://raw.githubusercontent.com/candrapersada/ani-cli/ffmpegpass2/ani-cli")" || die "Connection error"
     update="$(printf '%s\n' "$update" | diff -u "$0" -)"
     if [ -z "$update" ]; then
         printf "Script is up to date :)\n"
@@ -290,21 +290,20 @@ update_history() {
 download() {
     # download subtitle if it's set
     # [ -n "$subtitle" ] && curl -s "$subtitle" -o "$download_dir/$2.vtt"
-    [ -n "$subtitle" ] && mpegts=--hls-use-mpegts
+    ffmpegconvter="-c:v libx264 -vf scale='min(640,iw)':'min(360,ih)' -preset medium -c:a aac -b:v 132k -b:a 64k"
+    #ffmpegconvter="-c:v libx264 -vf scale='min(640,iw)':'min(360,ih)' -preset medium -c:a aac -b:v 132k -b:a 48k"
+    [ -n "$subtitle" ] && ffmpegsubtitle="-i $subtitle -c:s mov_text"
     case $1 in
         *m3u8*)
-            if command -v "yt-dlp" >/dev/null; then
-                [ ! -e "$download_dir/$2.mp4" ] && yt-dlp --referer "$m3u8_refr" "$1" $mpegts --no-skip-unavailable-fragments --fragment-retries infinite -N 4 -o "$TMP_DIR/$2.mp4"
-            else
-                [ ! -e "$download_dir/$2.mp4" ] && [ -n "$subtitle" ] && ffmpeg -referer "$m3u8_refr" -loglevel error -stats -i "$1" -i "$subtitle" -c copy -c:s mov_text "$TMP_DIR/$2.mp4" && mv "$TMP_DIR/$2.mp4" "$download_dir/$2.mp4"
-                [ ! -e "$download_dir/$2.mp4" ] && [ ! -n "$subtitle" ] && ffmpeg -referer "$m3u8_refr" -loglevel error -stats -i "$1" -c copy "$TMP_DIR/$2.mp4"
+            [ -e "$APPDATA" ] && extension_picky="-extension_picky 0"
+            [ ! -e "$download_dir/$2.mp4" ] && ffmpeg $extension_picky -referer "$m3u8_refr" -loglevel error -stats -i "$1" $ffmpegsubtitle $ffmpegconvter "$TMP_DIR/$2.mp4"
 
-            fi
             # embed subs into downloads
-            [ -n "$subtitle" ] && [ -e "$TMP_DIR/$2.mp4" ] && ffmpeg -loglevel error -i "$TMP_DIR/$2.mp4" -i "$subtitle" -c copy -c:s mov_text "$TMP_DIR/$2.bak.mp4" && mv "$TMP_DIR/$2.bak.mp4" "$TMP_DIR/$2.mp4"
+            # [ -n "$subtitle" ] && ffmpeg -loglevel error -i "$TMP_DIR/$2.mp4" -i "$subtitle" -c copy -c:s mov_text "$TMP_DIR/$2.bak.mp4" && mv "$TMP_DIR/$2.bak.mp4" "$TMP_DIR/$2.mp4"
             ;;
         *)
-            [ ! -e "$download_dir/$2.mp4" ] && aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue --async-dns=false --summary-interval=0 -x 16 -s 16 "$1" --dir="$TMP_DIR" -o "$2.mp4" --download-result=hide
+            [ ! -e "$download_dir/$2.mp4" ] && aria2c --referer="$allanime_refr" --enable-rpc=false --check-certificate=false --continue --async-dns=false --summary-interval=0 -x 1 -s 16 "$1" --dir="$TMP_DIR/aria2_temp" -o "$2.mp4" --download-result=hide && ffmpeg -loglevel error -stats -i "$TMP_DIR/aria2_temp/$2.mp4" $ffmpegsubtitle $ffmpegconvter "$TMP_DIR/$2.mp4"
+            #[ ! -e "$download_dir/$2.mp4" ] && ffmpeg $extension_picky -referer "$allanime_refr" -loglevel error -stats -i "$1" $ffmpegsubtitle $ffmpegconvter -pass 1 -passlogfile "$TMP_DIR/ffmpeg2pass" -f null /dev/null && ffmpeg $extension_picky -referer "$allanime_refr" -loglevel error -stats -i "$1" $ffmpegsubtitle $ffmpegconvter -pass 2 -passlogfile "$TMP_DIR/ffmpeg2pass" "$TMP_DIR/$2.mp4"
             ;;
     esac
 [ -e "$TMP_DIR/$2.mp4" ] && mv "$TMP_DIR/$2.mp4" "$download_dir/$2.mp4"


### PR DESCRIPTION
# Pull Request Template

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation update

## Description

*ramble here*

## Checklist

- [ ] any anime playing
- [ ] bumped version
---
- [ ] next, prev and replay work
- [ ] `-c` history and continue work
- [ ] `-d` downloads work
- [ ] `-s` syncplay works
- [ ] `-q` quality works
- [ ] `-v` vlc works
- [ ] `-e` (select episode) aka `-r` (range selection) works
- [ ] `-S` select index works
- [ ] `--skip` ani-skip works
- [ ] `--skip-title` ani-skip title argument works
- [ ] `--no-detach` no detach works
- [ ] `--exit-after-play` auto exit after playing works
- [ ] `--nextep-countdown` countdown to next ep works
- [ ] `--dub` and regular (sub) mode both work
- [ ] all providers return links (not necessarily on a single anime, use debug mode to confirm)
---
- [ ] `-h` help info is up to date
- [ ] Readme is up to date
- [ ] Man page is up to date

## Additional Testcases

- The safe bet: One Piece
- Episode 0: Saenai Heroine no Sodatekata ♭
- Unicode: Saenai Heroine no Sodatekata ♭
- Non-whole episodes: Tensei shitara slime datta ken (ep. 24.5, ep. 24.9)
- All Providers: Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e (TV) (3 m3u8, 3 mp4, 1 fast4speed, 1 sharepoint)
- The examples of the help text
